### PR TITLE
Introducing commands to get and stream logs from Chec.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,10 @@
     "mocha": "^5",
     "nock": "^11.4.0",
     "nyc": "^13",
+    "proxyquire": "^2.1.3",
     "sinon": "^7.5.0",
-    "sinon-chai": "^3.3.0"
+    "sinon-chai": "^3.3.0",
+    "strip-ansi": "^5.2.0"
   },
   "engines": {
     "node": ">=8.3.0"

--- a/package.json
+++ b/package.json
@@ -12,10 +12,14 @@
     "@oclif/plugin-help": "^2",
     "chalk": "^2.4.2",
     "cli-ux": "^5.3.2",
+    "clipboardy": "^2.1.0",
+    "date-format": "^2.1.0",
     "got": "^9.6.0",
     "inquirer": "^7.0.0",
+    "json-colorizer": "^2.2.1",
     "lodash.get": "^4.4.2",
     "ora": "3.4.0",
+    "pusher-js": "^5.0.2",
     "query-string": "^6.8.3"
   },
   "devDependencies": {

--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -16,14 +16,14 @@ class LogCommand extends Command {
     try {
       await log.getFullLog()
     } catch (error) {
-      spinner.stop()
-      return this.error(`Could not fetch the log "${logId}". Error: ${error.statusCode}`)
+      spinner.fail(`Could not fetch the log "${logId}". Error: ${error.statusCode}`)
+      return
     }
 
     spinner.stop()
 
     if (raw) {
-      this.log(await log.getFullLog())
+      this.log(JSON.stringify(await log.getFullLog()))
       return
     }
 

--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -47,7 +47,7 @@ LogCommand.flags = {
   }),
   utc: flags.boolean({
     default: false,
-    description: 'Display timestamps in UTC timezone',
+    description: 'Display timestamps in UTC timezone instead of the local timezone',
   }),
   ...globalFlags,
 }

--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -1,0 +1,59 @@
+const {Command, flags} = require('@oclif/command')
+const chalk = require('chalk')
+const ora = require('ora')
+const globalFlags = require('../helpers/global-flags')
+const LogEntry = require('../helpers/log-entry')
+
+class LogCommand extends Command {
+  async run() {
+    const {args: {logId}, flags: {domain, raw, utc}} = this.parse(LogCommand)
+    const log = new LogEntry({log_id: logId}, domain) // eslint-disable-line camelcase
+    const spinner = ora({
+      text: 'Fetching log from Chec.io...',
+      stream: process.stdout,
+    }).start()
+
+    try {
+      await log.getFullLog()
+    } catch (error) {
+      spinner.stop()
+      return this.error(`Could not fetch the log "${logId}". Error: ${error.statusCode}`)
+    }
+
+    spinner.stop()
+
+    if (raw) {
+      this.log(await log.getFullLog())
+      return
+    }
+
+    this.log(chalk.dim(log.formattedSummary(utc)))
+    this.log(await log.formattedLog())
+  }
+}
+
+LogCommand.args = [
+  {
+    name: 'logId',
+    required: true,
+    description: 'The log ID for the log entry you want to retrieve',
+  },
+]
+
+LogCommand.flags = {
+  raw: flags.boolean({
+    default: false,
+    description: 'Display a "raw" unformatted JSON blob of the log details',
+  }),
+  utc: flags.boolean({
+    default: false,
+    description: 'Display timestamps in UTC timezone',
+  }),
+  ...globalFlags,
+}
+
+LogCommand.description = `Get full detail about a given log ID
+Communicates with Chec.io to get full log information for the given log ID
+`
+
+module.exports = LogCommand

--- a/src/commands/logs.js
+++ b/src/commands/logs.js
@@ -128,7 +128,7 @@ class LogsCommand extends Command {
    * Wait for a key pressed by the user. The promise will error if an exit command in triggered by the user
    *
    * @param {string|function} matcher The key to match or a function that matches a given "key" object and returns a boolean
-   * @return {Promise<true>} Returns a promise that resolves when the given key ir pressed
+   * @return {Promise<true>} Returns a promise that resolves when the given key is pressed
    */
   async waitForKeyPress(matcher) {
     // Register a one-time event handler for a "keypress input"

--- a/src/commands/logs.js
+++ b/src/commands/logs.js
@@ -1,0 +1,373 @@
+const {Command, flags} = require('@oclif/command')
+const Pusher = require('pusher-js')
+const chalk = require('chalk')
+const readline = require('readline')
+const inquirer = require('inquirer')
+const {once} = require('events')
+const ora = require('ora')
+const clipboardy = require('clipboardy')
+const LogEntry = require('../helpers/log-entry')
+const globalFlags = require('../helpers/global-flags')
+const config = require('../helpers/config')
+const requestHelper = require('../helpers/request')
+
+class LogsCommand extends Command {
+  async run() {
+    const {flags: {tail, follow, domain}} = this.parse(LogsCommand)
+    this.logs = []
+
+    // Clear the screen now if we're going to be listening eventually
+    if (follow) {
+      this.clearScreen()
+    }
+
+    // Handle a request to start with a given number of logs
+    if (tail > 0) {
+      this.spinner('Fetching logs from Chec.io...')
+      this.logs = await requestHelper.request(
+        'GET',
+        '/v1/developer/logs',
+        {last: tail},
+        {domain}
+      ).then(response => JSON.parse(response.body).map(entry => new LogEntry(entry, domain)))
+      this.spinner(null)
+
+      this.printLogs()
+    }
+
+    // We've tailed some logs, we can close out if we're not listening
+    if (!follow) {
+      return
+    }
+
+    // Register the listener
+    this.registerWebsocket()
+
+    // Run the main loop
+    try {
+      await this.loop()
+    } catch (error) {
+      this.error(error)
+    }
+
+    // Stop the spinner and disconnect before stopping
+    this.spinner(null)
+    this.socket.disconnect()
+  }
+
+  /**
+   * The "main loop" of this long-running command.
+   */
+  async loop() {
+    // Always reset the "canLog" tracker
+    this.canLog = true
+
+    // Wait for the user to navigation logs
+    if (!await this.handleNavigation()) {
+      return
+    }
+
+    // Trim the log count
+    this.pruneLogs()
+
+    // Print the rest of the logs
+    this.printLogs()
+
+    // Recurse
+    await this.loop()
+  }
+
+  /**
+   * Register the pusher websocket and handler for new logs coming in
+   */
+  registerWebsocket() {
+    const {flags: {domain, utc}} = this.parse(LogsCommand)
+    const {key, token} = config.get('notifications')
+    const socket = new Pusher(key, {cluster: 'us3'})
+    const channel = socket.subscribe(`api.logs.${token}`)
+    const navigationPrompt = this.logs.length > 0 ? 'Press "up" to navigate through the exisiting logs' : ''
+
+    channel.bind('log', ({log}) => {
+      const entry = new LogEntry(log, domain)
+
+      // Check if we're waiting
+      if (this.canLog) {
+        // Stop the spinner
+        this.spinner(null)
+
+        // Print the line
+        this.log(entry.formattedSummary(utc))
+        entry.setPrinted()
+
+        // Restart the spinner
+        this.spinner(`Listening for logs from Chec.io. ${navigationPrompt}`)
+
+        // Keep logs pruned
+        this.pruneLogs()
+      }
+
+      // Append the log
+      this.logs.push(entry)
+    })
+
+    this.spinner(`Listening for logs from Chec.io. ${navigationPrompt}`)
+
+    this.socket = socket
+  }
+
+  /**
+   * Wait for a key pressed by the user. The promise will error if an exit command in triggered by the user
+   *
+   * @param {string|function} matcher The key to match or a function that matches a given "key" object and returns a boolean
+   * @return {Promise<true>} Returns a promise that resolves when the given key ir pressed
+   */
+  async waitForKeyPress(matcher) {
+    // Register a one-time event handler for a "keypress input"
+    return once(readline.createInterface({
+      terminal: true,
+      input: process.stdin,
+      output: process.stdout,
+    }).input, 'keypress').then(([_, key]) => {
+      // Handle an exit sequence and throw an error to fail the promise
+      if (key.ctrl && ['z', 'c'].includes(key.name)) {
+        throw new Error('exit')
+      }
+
+      // Clear the line to prevent input from showing
+      process.stdout.clearLine()
+      process.stdout.cursorTo(0)
+
+      // Check if the key matches
+      if ((typeof matcher === 'function' && matcher(key)) || matcher === key.name) {
+        return true
+      }
+
+      // Queue the same event handler if the key didn't match
+      return this.waitForKeyPress(matcher)
+    })
+  }
+
+  /**
+   * An asyncronous handler for the user attempting to navigate logs while streaming.
+   *
+   * @returns {Promise<boolean>} Reutrns a promise that resolves to a boolean whether the application should continue (or exit)
+   */
+  async handleNavigation() {
+    // "up" launches into an interactive session to get full versions of prior logs. Skip anything else
+    try {
+      await this.waitForKeyPress('up')
+    } catch (error) {
+      return false
+    }
+
+    // Don't do anything if there's no logs, just keep waiting for input
+    if (this.logs.length === 0) {
+      return this.handleNavigation()
+    }
+
+    // Ensure we don't log now
+    this.canLog = false
+
+    // Ask the user for a log
+    const log = await this.promptForLog()
+
+    // If the user cancelled, go back to waiting
+    if (!log) {
+      this.clearScreen()
+      await this.printLogs()
+      this.canLog = true
+      return this.handleNavigation()
+    }
+
+    // Fetch the individual log entry
+    this.spinner('Fetching log from Chec.io...')
+    const raw = await log.getFullLog()
+    this.spinner(null)
+
+    // Fetch the UTC preference from command flags
+    const {flags: {utc}} = this.parse(LogsCommand)
+
+    // Clear the screen and display the log
+    this.clearScreen()
+    this.log(chalk.dim(log.formattedSummary(utc)))
+    this.log(await log.formattedLog())
+    this.log('')
+    this.log('Press "enter" to return to streaming logs or "c" to copy to clipboard')
+
+    // Register a handler to copy the response and ignore any failures
+    this.waitForKeyPress('c').then(() => {
+      clipboardy.write(JSON.stringify(raw, null, 2))
+    }).catch(() => {})
+
+    // Wait for them to press enter
+    try {
+      await this.waitForKeyPress('return')
+    } catch (error) {
+      return false
+    }
+
+    // Clean up the console for the logs to be displayed again
+    this.clearScreen()
+
+    return true
+  }
+
+  /**
+   * Prompt the user to choose a log from the internally kept history of logs. The list is shown with recent logs
+   * first but a number of logs can be excluded of the end by provding a "reverseOffset"
+   *
+   * @param {integer} reverseOffset The number of logs to skip from the end of the logs list
+   * @param {integer} logCount The number of logs to show to the user to choose from
+   * @returns {Promise<LogEntry|null>} A promise that resolves to the log entry the user chose or null if cancelled
+   */
+  async promptForLog(reverseOffset = 0, logCount = 10) {
+    // Fetch the UTC preference from command flags
+    const {flags: {utc}} = this.parse(LogsCommand)
+    // Get the logs, taking off a given number from the end
+    const logs = reverseOffset > 0 ? this.logs.slice(0, this.logs.length - reverseOffset) : this.logs
+    // Slice the specific logs that need to be presented
+    const logsToPresent = logs.length <= logCount ? logs : logs.slice(this.logs.length - logCount)
+    // Map them into "choices" for inquirer
+    const choices = logsToPresent.map((entry, index) => ({name: entry.formattedSummary(utc), value: index}))
+
+    // Add a "view more" option if there's more logs in the history
+    if (logs.length > logCount) {
+      choices.unshift({name: 'View more...', value: -1})
+    }
+
+    // Add a "cancel" option
+    choices.push({name: 'Cancel', value: false})
+
+    // Stop the spinner and clear the screen
+    this.spinner(null)
+    this.clearScreen()
+
+    // Show the user the list of logs (formatted the same way)
+    const {response} = await inquirer.prompt([{
+      type: 'list',
+      name: 'response',
+      message: 'Choose an entry to view:',
+      choices,
+      default: choices.length - 2,
+      pageSize: choices.length,
+    }])
+
+    // `false` means they chose "Cancel"
+    if (response === false) {
+      return null
+    }
+
+    // Check if the user chose "View more"
+    if (response < 0) {
+      return this.promptForLog(reverseOffset + logCount, logCount)
+    }
+
+    // Return the log that was chosen
+    return logsToPresent[response]
+  }
+
+  /**
+   * Print logs that have been queueing
+   */
+  printLogs() {
+    // Find the first index of an unprinted log
+    const unprinted = this.logs.findIndex(log => !log.printed)
+
+    // Bail if there's nothing to print
+    if (unprinted < 0) {
+      return
+    }
+
+    // Fetch the UTC preference from command flags
+    const {flags: {utc}} = this.parse(LogsCommand)
+
+    // Slice just those logs and print them
+    const updated = this.logs.slice(unprinted)
+    updated.forEach(log => {
+      this.log(log.formattedSummary(utc))
+      log.setPrinted()
+    })
+
+    // Splice in the logs that have been printed
+    this.logs.splice(unprinted, updated.length, ...updated)
+
+    // Recurse until logs are printed. It's slightly possible that logs might come in while catching up
+    this.printLogs()
+  }
+
+  /**
+   * Trim the logs cache to a the number of entries defined by user argument
+   */
+  pruneLogs() {
+    const {flags: {history}} = this.parse(LogsCommand)
+    if (this.logs.length > history) {
+      this.logs = this.logs.slice(this.logs.length - history)
+    }
+  }
+
+  /**
+   * Show or cancel the spinner
+   *
+   * @param {string|null} text The text to show on the spinner (or null to stop the spinner)
+   */
+  spinner(text) {
+    // Stop any existing instance
+    if (this.spinnerInstance) {
+      this.spinnerInstance.stop()
+    }
+
+    // We're done if we're trying ot cancel
+    if (text === null) {
+      return
+    }
+
+    // Re-create the spinner with the given text
+    this.spinnerInstance = ora({
+      text,
+      stream: process.stdout,
+    }).start()
+  }
+
+  /**
+   * Clear the console for the user
+   */
+  clearScreen() {
+    console.clear() // eslint-disable-line no-console
+
+    // Mark logs to be reprinted
+    const logCount = this.logs.length
+    const count = process.stdout.rows || logCount
+    const toPrint = logCount > count ? this.logs.slice(logCount - count) : this.logs
+    toPrint.forEach(entry => entry.setPrinted(false))
+  }
+}
+
+LogsCommand.flags = {
+  tail: flags.integer({
+    char: 'n',
+    default: 0,
+    description: 'Show the last n number of logs before listening for new logs',
+  }),
+  follow: flags.boolean({
+    char: 'f',
+    default: true,
+    allowNo: true,
+    description: '"Follow" logs from Chec.io. New events that happen are shown live',
+  }),
+  history: flags.integer({
+    char: 'h',
+    default: 100,
+    description: 'Keep record of the given number of logs when tailing for browsing back.',
+  }),
+  utc: flags.boolean({
+    default: false,
+    description: 'Display timestamps in UTC timezone',
+  }),
+  ...globalFlags,
+}
+
+LogsCommand.description = `Show a summary of your API requests processed by Chec.io
+Listens for logs from Chec.io and displays a summary of them to you as they are processed by Chec.
+You may optionally retrieve prior logs and navigate through shown logs to fetch further details about the log entry from Chec.io.
+`
+module.exports = LogsCommand

--- a/src/commands/request.js
+++ b/src/commands/request.js
@@ -11,8 +11,7 @@ const ora = require('ora')
 class RequestCommand extends Command {
   async run() {
     if (!authHelper.isLoggedIn()) {
-      this.error('You must be logged in to use this command. Run `chec login` to get started.')
-      this.exit(1)
+      return this.error('You must be logged in to use this command. Run `chec login` to get started.')
     }
 
     const spinner = ora({

--- a/src/helpers/auth.js
+++ b/src/helpers/auth.js
@@ -52,6 +52,7 @@ class Auth {
    */
   logout() {
     this.config.remove('keys')
+    this.config.remove('notifications')
   }
 }
 

--- a/src/helpers/config.js
+++ b/src/helpers/config.js
@@ -33,7 +33,12 @@ class Config {
   load() {
     if (!this.config) {
       this.config = {}
-      const file = fs.readFileSync(this.configPath())
+      let file
+      try {
+        file = fs.readFileSync(this.configPath())
+      } catch (error) {
+        return {}
+      }
       if (file.length === 0) {
         return this.config
       }

--- a/src/helpers/log-entry.js
+++ b/src/helpers/log-entry.js
@@ -12,6 +12,12 @@ module.exports = class LogEntry {
    * @param {string} domain The domain that issued this log, for fetching further information about the log
    */
   constructor(rawEntry, domain = 'chec.io') {
+    const {log_id: logId} = rawEntry
+
+    if (!logId) {
+      throw new Error('LogEntry must be given a "raw" entry that at least contains the `log_id`')
+    }
+
     this.raw = rawEntry
     this.domain = domain
     this.printed = false
@@ -68,29 +74,12 @@ module.exports = class LogEntry {
   }
 
   /**
-   * Format a log entry into a line that can be logged on the CLI
-   *
-   * @param {boolean} utc Indicates timestamps should be UTC
-   * @return {string} A formatted string to log
-   */
-  formattedSummary(utc = false) {
-    const {status_code: statusCode, log_id: id, url} = this.raw
-
-    const date = chalk.dim(`[${this.getFormattedDate(utc)}]`)
-    const responseCodeColor = statusCode >= 200 && statusCode < 300 ? 'bgGreen' :
-      statusCode >= 300 && statusCode < 400 ? 'bgYellow' : 'bgRed'
-    const responseCode = chalk[responseCodeColor](` ${chalk.black(statusCode)} `)
-
-    return `${date} ${responseCode} ${chalk.yellow(id)} ${url}`
-  }
-
-  /**
    * Get a formatted date string for this log entry
    *
    * @param {boolean} utc Indicates timestamps should be UTC
    * @returns {string} The formatted date
    */
-  getFormattedDate(utc = false) {
+  formattedDate(utc = false) {
     const {time} = this.raw
     const suffix = utc ? 'O' : ''
     const parsedDate = dateFormat(`yyyy-MM-dd hh:mm:ss${suffix}`, new Date(time * 1000))
@@ -100,5 +89,22 @@ module.exports = class LogEntry {
     }
 
     return parsedDate.substring(0, parsedDate.length - 5)
+  }
+
+  /**
+   * Format a log entry into a line that can be logged on the CLI
+   *
+   * @param {boolean} utc Indicates timestamps should be UTC
+   * @return {string} A formatted string to log
+   */
+  formattedSummary(utc = false) {
+    const {status_code: statusCode, log_id: id, url} = this.raw
+
+    const date = chalk.dim(`[${this.formattedDate(utc)}]`)
+    const responseCodeColor = statusCode >= 200 && statusCode < 300 ? 'bgGreen' :
+      statusCode >= 300 && statusCode < 400 ? 'bgYellow' : 'bgRed'
+    const responseCode = chalk[responseCodeColor](` ${chalk.black(statusCode)} `)
+
+    return `${date} ${responseCode} ${chalk.yellow(id)} ${url}`
   }
 }

--- a/src/helpers/log-entry.js
+++ b/src/helpers/log-entry.js
@@ -1,0 +1,104 @@
+const requestHelper = require('./request')
+const chalk = require('chalk')
+const dateFormat = require('date-format')
+const colorise = require('json-colorizer')
+
+/**
+ * A "model" that represents a log entry provided by Chec.io
+ */
+module.exports = class LogEntry {
+  /**
+   * @param {object} rawEntry The entry provided by Chec.io
+   * @param {string} domain The domain that issued this log, for fetching further information about the log
+   */
+  constructor(rawEntry, domain = 'chec.io') {
+    this.raw = rawEntry
+    this.domain = domain
+    this.printed = false
+    this.full = Object.hasOwnProperty.call(rawEntry, 'response')
+  }
+
+  /**
+   * @returns {integer} The log ID for this entry
+   */
+  id() {
+    return this.raw.log_id
+  }
+
+  /**
+   * Indicatee this log entry has (or hasn't) been printed
+   *
+   * @param {boolean} printed Whether the entry should be recorded as printed
+   */
+  setPrinted(printed = true) {
+    this.printed = printed
+  }
+
+  /**
+   * Get the full log details for this entry
+   *
+   * @returns {Promise<object>} The object representation of the log
+   */
+  async getFullLog() {
+    // Resolve immediately if we've already got the "full" log
+    if (this.full) {
+      return this.raw
+    }
+
+    // Retrieve all details for the log
+    this.raw = await requestHelper.request(
+      'GET',
+      `/v1/developer/logs/${this.id()}`,
+      null,
+      {domain: this.domain}
+    ).then(response => JSON.parse(response.body))
+
+    // Indicate we've got the full log now
+    this.full = true
+    return this.raw
+  }
+
+  /**
+   * Return a colourised log for output to the CLI
+   *
+   * @returns {Promise<string>} Colourised string for the CLI
+   */
+  async formattedLog() {
+    return colorise(await this.getFullLog(), {pretty: true})
+  }
+
+  /**
+   * Format a log entry into a line that can be logged on the CLI
+   *
+   * @param {boolean} utc Indicates timestamps should be UTC
+   * @return {string} A formatted string to log
+   */
+  formattedSummary(utc = false) {
+    const {status_code: statusCode, log_id: id, url} = this.raw
+
+    const date = chalk.dim(`[${this.getFormattedDate(utc)}]`)
+    const responseCodeColor = statusCode >= 200 && statusCode < 300 ? 'bgGreen' :
+      statusCode >= 300 && statusCode < 400 ? 'bgYellow' : 'bgRed'
+    const responseCode = chalk[responseCodeColor](` ${chalk.black(statusCode)} `)
+
+    return `${date} ${responseCode} ${chalk.yellow(id)} ${url}`
+  }
+
+  /**
+   * Get a formatted date string for this log entry
+   *
+   * @param {boolean} utc Indicates timestamps should be UTC
+   * @returns {string} The formatted date
+   */
+  getFormattedDate(utc = false) {
+    const {time} = this.raw
+    const suffix = utc ? 'O' : ''
+    const parsedDate = dateFormat(`yyyy-MM-dd hh:mm:ss${suffix}`, new Date(time * 1000))
+
+    if (!utc) {
+      return parsedDate
+    }
+
+    return parsedDate.substring(0, parsedDate.length - 5)
+  }
+}

--- a/src/helpers/log-feed.js
+++ b/src/helpers/log-feed.js
@@ -1,0 +1,40 @@
+const Pusher = require('pusher-js')
+const config = require('../helpers/config')
+
+module.exports = class LogFeed {
+  constructor() {
+    this.socket = null
+    this.channel = null
+  }
+
+  getConfiguration() {
+    const credentials = config.get('notifications')
+
+    if (!credentials) {
+      throw new Error('Could not locate required credentials to subscribe to a log feed')
+    }
+
+    const {key, token} = credentials
+    return {key, token}
+  }
+
+  onLog(listener) {
+    this.getChannel().bind('log', ({log}) => listener(log))
+  }
+
+  getChannel() {
+    if (!this.channel) {
+      const {key, token} = this.getConfiguration()
+      this.socket = new Pusher(key, {cluster: 'us3'})
+      this.channel = this.socket.subscribe(`api.logs.${token}`)
+    }
+
+    return this.channel
+  }
+
+  disconnect() {
+    if (this.socket) {
+      this.socket.disconnect()
+    }
+  }
+}

--- a/src/helpers/login.js
+++ b/src/helpers/login.js
@@ -43,13 +43,21 @@ module.exports = {
       throw new LoginError('User not found', true)
     }
 
-    const keys = JSON.parse(response.body)
+    const {body, headers} = response
+    const keys = JSON.parse(body)
 
     if (!Array.isArray(keys) || keys.length === 0) {
       throw new LoginError('An unexpected error occurred (MISSING_KEYS)')
     }
 
     // Write the key
-    authHelper.config.save({keys})
+    authHelper.config.set({keys})
+
+    if (Object.prototype.hasOwnProperty.call(headers, 'x-notification-key')) {
+      authHelper.config.set({notifications: {
+        token: headers['x-notification-token'],
+        key: headers['x-notification-key'],
+      }})
+    }
   },
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "rules": {
+      // chai allows this for assertions (eg. expect().to.be.null)
+      "no-unused-expressions": "off"
+  }
+}

--- a/test/commands/log.test.js
+++ b/test/commands/log.test.js
@@ -1,0 +1,95 @@
+/* global beforeEach afterEach */
+
+const {test} = require('@oclif/test')
+const sinon = require('sinon')
+const LogEntry = require('../../src/helpers/log-entry')
+const chai = require('chai')
+const sinonChai = require('sinon-chai')
+
+const {expect} = chai
+chai.use(sinonChai)
+
+const fakeFullLog = {
+  log_id: 123, // eslint-disable-line camelcase
+  status_code: 201, // eslint-disable-line camelcase
+  url: '/v1/fake/endpoint',
+  time: 1572304602,
+  response: {content: 'test response'},
+}
+
+describe('log', () => {
+  let getFullLogStub
+  let formattedSummaryStub
+  let formattedLogStub
+
+  beforeEach(() => {
+    getFullLogStub = sinon.stub(LogEntry.prototype, 'getFullLog')
+    getFullLogStub.resolves(fakeFullLog)
+
+    formattedSummaryStub = sinon.stub(LogEntry.prototype, 'formattedSummary')
+    formattedSummaryStub.returns('a formatted summary')
+
+    formattedLogStub = sinon.stub(LogEntry.prototype, 'formattedLog')
+    formattedLogStub.resolves('a formatted log')
+  })
+
+  afterEach(() => {
+    getFullLogStub.restore()
+    formattedSummaryStub.restore()
+    formattedLogStub.restore()
+  })
+
+  test
+  .stdout()
+  .command(['log', 'abc_123'])
+  .it('will return a formatted log entry', ctx => {
+    expect(ctx.stdout).to.contain('a formatted log')
+  })
+
+  test
+  .stdout()
+  .command(['log', 'abc_123'])
+  .it('will display a summary too', ctx => {
+    expect(ctx.stdout).to.contain('a formatted summary')
+  })
+
+  test
+  .stdout()
+  .command(['log', 'abc_123'])
+  .it('does not ask for UTC time formats', () => {
+    expect(formattedSummaryStub).to.have.been.called
+    expect(formattedSummaryStub).not.to.have.been.calledWith(true)
+  })
+
+  test
+  .stdout()
+  .command(['log', 'abc_123', '--utc'])
+  .it('will call methods with UTC configuration only if specified', () => {
+    expect(formattedSummaryStub).to.have.been.called
+    expect(formattedSummaryStub).to.have.been.calledWith(true)
+  })
+
+  test
+  .stdout()
+  .command(['log', 'abc_123', '--raw'])
+  .it('will display a JSON blob if the --raw flag is specified', ctx => {
+    expect(ctx.stdout).to.contain(JSON.stringify(fakeFullLog))
+    expect(ctx.stdout).not.to.contain('a formatted log')
+    expect(ctx.stdout).not.to.contain('a formatted summary')
+  })
+
+  test
+  .stdout()
+  .do(() => {
+    getFullLogStub.throws(new class extends Error {
+      constructor(message) {
+        super(message)
+        this.statusCode = 999
+      }
+    }('bad'))
+  })
+  .command(['log', 'abc_123'])
+  .it('indicates a failure when fetching a log and specifies the status code', ctx => {
+    expect(ctx.stdout).to.contain('Could not fetch the log "abc_123". Error: 999')
+  })
+})

--- a/test/commands/login.test.js
+++ b/test/commands/login.test.js
@@ -16,15 +16,18 @@ describe('login', () => {
 
   let configSupportedStub
   let configGetStub
+  let configSetStub
   beforeEach(() => {
     configSupportedStub = sinon.stub(config, 'supported')
     configSupportedStub.returns(true)
     configGetStub = sinon.stub(config, 'get')
     configGetStub.returns([])
+    configSetStub = sinon.stub(config, 'set')
   })
   afterEach(() => {
     configSupportedStub.restore()
     configGetStub.restore()
+    configSetStub.restore()
     auth.keys = null
   })
 

--- a/test/commands/logs.test.js
+++ b/test/commands/logs.test.js
@@ -1,0 +1,378 @@
+/* global beforeEach afterEach */
+
+const {test} = require('@oclif/test')
+const sinon = require('sinon')
+const clipboardy = require('clipboardy')
+const chai = require('chai')
+const sinonChai = require('sinon-chai')
+const inquirer = require('inquirer')
+const readline = require('readline')
+const stripAnsi = require('strip-ansi')
+const LogFeed = require('../../src/helpers/log-feed')
+const LogEntry = require('../../src/helpers/log-entry')
+const requestHelper = require('../../src/helpers/request')
+
+const {expect} = chai
+chai.use(sinonChai)
+
+class FakeFeed {
+  constructor() {
+    this.callbacks = []
+    this.onLogFake = sinon.stub(LogFeed.prototype, 'onLog')
+    this.onLogFake.callsFake(callback => {
+      this.callbacks.push(callback)
+    })
+
+    this.disconnectFake = sinon.stub(LogFeed.prototype, 'disconnect')
+  }
+
+  sendLog(log) {
+    this.callbacks.forEach(callback => callback(log))
+  }
+}
+
+const fakePartialLog = {
+  log_id: 123, // eslint-disable-line camelcase
+  status_code: 201, // eslint-disable-line camelcase
+  url: '/v1/fake/endpoint',
+  time: 1572304602,
+}
+const fakeFullLog = {
+  ...fakePartialLog,
+  response: {content: 'test response'},
+}
+const fakeLogEntry = new LogEntry(fakeFullLog)
+
+const emitKeypress = (key, ctrl = false) => {
+  readline.createInterface({
+    terminal: true,
+    input: process.stdin,
+    output: process.stdout,
+  }).input.emit('keypress', key, {name: key, ctrl})
+}
+
+const makeTimedExtension = callback => (time, ...args) => {
+  return {
+    timeout: null,
+    run() {
+      this.timeout = setTimeout(() => callback(...args), time * 2)
+    },
+    finally() {
+      clearTimeout(this.timeout)
+    },
+  }
+}
+
+let fakeFeed
+
+const base = test
+// Register specific testing helpers for this command
+.register('quitsAfter', makeTimedExtension(() => emitKeypress('c', true)))
+.register('pressesAfter', makeTimedExtension((key, ctrl = false) => emitKeypress(key, ctrl)))
+.register('receivesLogAfter', makeTimedExtension(log => {
+  if (fakeFeed) {
+    fakeFeed.sendLog(log)
+  }
+}))
+// Retry all these flakey tests
+.retries(2)
+
+describe('logs', () => {
+  let consoleClearMock
+  let testTimeout
+
+  beforeEach(() => {
+    consoleClearMock = sinon.stub(console, 'clear')
+    fakeFeed = new FakeFeed()
+
+    // Give all runs a hard limit of 4 seconds before sending a SIGINT
+    testTimeout = setTimeout(() => {
+      emitKeypress('c', true)
+    }, 4000)
+  })
+
+  afterEach(() => {
+    consoleClearMock.restore()
+    clearTimeout(testTimeout)
+    fakeFeed.onLogFake.restore()
+    fakeFeed.disconnectFake.restore()
+  })
+
+  // Basic log display:
+  base
+  .stdout()
+  .quitsAfter(10) // For some reason the first one's a bit dicier
+  .command('logs')
+  .it('should indicate that it\'s waiting for logs', ctx => {
+    expect(ctx.stdout).to.contain('Listening for logs from Chec.io.')
+  })
+
+  base
+  .stdout()
+  .quitsAfter(20)
+  .command('logs')
+  .it('should clear the console when listening', () => {
+    expect(consoleClearMock).to.have.been.called
+  })
+
+  base
+  .stdout()
+  .quitsAfter(20)
+  .receivesLogAfter(10, fakePartialLog)
+  .command('logs')
+  .it('should display a log when it comes in', ctx => {
+    expect(ctx.stdout).to.contain(stripAnsi(fakeLogEntry.formattedSummary()))
+  })
+
+  base
+  .stdout()
+  .quitsAfter(20)
+  .receivesLogAfter(10, fakePartialLog)
+  .command('logs')
+  .it('should update the listening message when there is at least one log on the screen', ctx => {
+    expect(ctx.stdout).to.contain('Press "up" to navigate through the exisiting logs')
+  })
+
+  // Tailing existing logs at the beginning
+  base
+  .stub(requestHelper, 'request', sinon.stub().resolves({body: JSON.stringify((new Array(5)).fill(fakePartialLog))}))
+  .stdout()
+  .quitsAfter(10)
+  .command(['logs', '-n5'])
+  .it('Will send a request to get logs from Chec.io', ctx => {
+    expect(requestHelper.request).to.have.been.calledOnceWith(
+      'GET',
+      '/v1/developer/logs',
+      {last: 5},
+      {domain: 'chec.io'},
+    )
+    expect(ctx.stdout).to.contain(stripAnsi(fakeLogEntry.formattedSummary()))
+  })
+
+  base
+  .stub(requestHelper, 'request', sinon.stub().resolves({body: JSON.stringify((new Array(5)).fill(fakePartialLog))}))
+  .stdout()
+  .timeout(10) // This timeout for the test should assert the expectation is resolved before the 4 second cancel above
+  .command(['logs', '-n5', '--no-follow'])
+  .it('Will not start a blocking process if given --no-follow', ctx => {
+    expect(ctx.stdout).to.contain(stripAnsi(fakeLogEntry.formattedSummary()))
+  })
+
+  // Asking user to choose logs to view
+  base
+  .stdout()
+  .stub(inquirer, 'prompt', sinon.fake.returns({
+    response: false,
+  }))
+  .quitsAfter(50)
+  .pressesAfter(25, 'up')
+  .command('logs')
+  .it('Should ignore the users up key without logs', () => {
+    expect(inquirer.prompt).not.to.have.been.called
+  })
+
+  base
+  .stdout()
+  .stub(inquirer, 'prompt', sinon.fake.returns({
+    response: false,
+  }))
+  .quitsAfter(50)
+  .receivesLogAfter(10, fakePartialLog)
+  .pressesAfter(25, 'up')
+  .command('logs')
+  .it('Should inquire the user to choose a log when the user presses up with at least one log showing', () => {
+    expect(inquirer.prompt).to.have.been.calledOnce
+    expect(inquirer.prompt.firstCall.args[0]).to.be.an('array').that.has.lengthOf(1)
+    expect(inquirer.prompt.firstCall.args[0][0]).to.deep.include({
+      type: 'list',
+      name: 'response',
+      message: 'Choose an entry to view:',
+      choices: [
+        {
+          name: fakeLogEntry.formattedSummary(),
+          value: 0,
+        },
+        {
+          name: 'Cancel',
+          value: false,
+        },
+      ],
+      default: 0,
+      pageSize: 2,
+    })
+  })
+
+  base
+  .stdout()
+  .stub(inquirer, 'prompt', sinon.fake.returns({
+    response: false,
+  }))
+  .quitsAfter(60)
+  .receivesLogAfter(10, fakePartialLog)
+  .receivesLogAfter(10, fakePartialLog)
+  .pressesAfter(25, 'up')
+  .command('logs')
+  .it('Should default the user choice to the most recent log', () => {
+    expect(inquirer.prompt).to.have.been.calledOnce
+    expect(inquirer.prompt.firstCall.args[0][0]).to.deep.include({
+      default: 1,
+      pageSize: 3,
+    })
+  })
+
+  base
+  .stub(requestHelper, 'request', sinon.stub().resolves({body: JSON.stringify((new Array(15)).fill(fakePartialLog))}))
+  .stub(inquirer, 'prompt', sinon.fake.returns({
+    response: false,
+  }))
+  .quitsAfter(30)
+  .pressesAfter(15, 'up')
+  .stdout()
+  .command(['logs', '-n15'])
+  .it('Should limit the number of options for the user', () => {
+    expect(inquirer.prompt).to.have.been.calledOnce
+    const {choices} = inquirer.prompt.firstCall.args[0][0]
+    expect(choices).to.deep.include({
+      name: 'View more...',
+      value: -1,
+    })
+    expect(choices).to.have.lengthOf(12)
+  })
+
+  base
+  .stub(requestHelper, 'request', sinon.stub().resolves({body: JSON.stringify((new Array(15)).fill(fakePartialLog))}))
+  .stub(inquirer, 'prompt', (() => {
+    const stub = sinon.stub()
+    stub.onCall(0).resolves({response: -1})
+    stub.onCall(1).resolves({response: false})
+    return stub
+  })())
+  .quitsAfter(30)
+  .pressesAfter(15, 'up')
+  .stdout()
+  .command(['logs', '-n15'])
+  .it('Should should show the remainder of the logs when choosing "view more"', () => {
+    expect(inquirer.prompt).to.have.been.calledTwice
+    const {choices} = inquirer.prompt.secondCall.args[0][0]
+    expect(choices).to.have.lengthOf(6)
+    expect(choices).to.deep.include({
+      name: 'Cancel',
+      value: false,
+    })
+    expect(choices).not.to.deep.include({
+      name: 'View more...',
+      value: -1,
+    })
+  })
+
+  base
+  .stub(requestHelper, 'request', sinon.stub().resolves({body: JSON.stringify((new Array(15)).fill(fakePartialLog))}))
+  .stub(inquirer, 'prompt', sinon.fake.returns({
+    response: false,
+  }))
+  .quitsAfter(30)
+  .pressesAfter(15, 'up')
+  .stdout()
+  .command(['logs', '-n15', '-h7'])
+  .it('Should only prompt for as many records as allowed in history', () => {
+    expect(inquirer.prompt).to.have.been.calledOnce
+    const {choices} = inquirer.prompt.firstCall.args[0][0]
+    expect(choices).to.have.lengthOf(8)
+    expect(choices).not.to.deep.include({
+      name: 'View more...',
+      value: -1,
+    })
+  })
+
+  base
+  .stub(requestHelper, 'request', sinon.stub().resolves({body: JSON.stringify(fakeFullLog)}))
+  .stub(inquirer, 'prompt', sinon.fake.returns({
+    response: 0,
+  }))
+  .stdout()
+  .quitsAfter(50)
+  .receivesLogAfter(10, fakePartialLog)
+  .pressesAfter(25, 'up')
+  .command('logs')
+  .it('Should dispatch a request for a full log when chosen by the user', () => {
+    expect(requestHelper.request).to.have.been.calledOnceWith(
+      'GET',
+      '/v1/developer/logs/123',
+      null,
+      {domain: 'chec.io'}
+    )
+  })
+
+  base
+  .stub(requestHelper, 'request', sinon.stub().resolves({body: JSON.stringify(fakeFullLog)}))
+  .stub(inquirer, 'prompt', sinon.fake.returns({
+    response: 0,
+  }))
+  .stdout()
+  .quitsAfter(50)
+  .receivesLogAfter(10, fakePartialLog)
+  .pressesAfter(25, 'up')
+  .command('logs')
+  .it('Should show the full log that the user chose', ctx => {
+    expect(ctx.stdout).to.contain(JSON.stringify(fakeFullLog, null, 2))
+    expect(ctx.stdout).to.contain('Press "enter" to return to streaming logs or "c" to copy to clipboard')
+  })
+
+  base
+  .stub(requestHelper, 'request', sinon.stub().resolves({body: JSON.stringify(fakeFullLog)}))
+  .stub(inquirer, 'prompt', sinon.fake.returns({
+    response: 0,
+  }))
+  .stub(clipboardy, 'write', sinon.stub())
+  .stdout()
+  .quitsAfter(70)
+  .receivesLogAfter(10, fakePartialLog)
+  .pressesAfter(25, 'up')
+  .pressesAfter(50, 'c')
+  .command('logs')
+  .it('Should copy the full log to clipboard when the correct key is pressed', () => {
+    expect(clipboardy.write).to.have.been.calledOnceWith(JSON.stringify(fakeFullLog, null, 2))
+  })
+
+  base
+  .stub(requestHelper, 'request', sinon.stub().resolves({body: JSON.stringify(fakeFullLog)}))
+  .stub(inquirer, 'prompt', sinon.fake.returns({
+    response: 0,
+  }))
+  .stdout()
+  .quitsAfter(50)
+  .receivesLogAfter(10, fakePartialLog)
+  .pressesAfter(20, 'up')
+  .pressesAfter(30, 'return')
+  .command('logs')
+  .it('Should return to streaming logs after choosing an item and pressing enter', ctx => {
+    const [, sincePrompt] = ctx.stdout.split('Press "enter" to return to streaming logs or "c" to copy to clipboard', 2)
+    expect(sincePrompt).to.contain(stripAnsi(fakeLogEntry.formattedSummary()))
+    expect(sincePrompt).to.contain('Listening for logs from Chec.io.')
+  })
+
+  // Error handling
+  base
+  .stub(requestHelper, 'request', sinon.stub().rejects({response: {statusCode: 401}}))
+  .stdout()
+  .quitsAfter(10)
+  .command(['logs', '-n5'])
+  .it('Will gracefully show errors when fetching a tail', ctx => {
+    expect(ctx.stdout).to.contain('Failed to fetch initial logs from Chec.io. (401)')
+  })
+
+  // The following test is working but seems to hang the console after it runs. Not sure why yet...
+  base
+  .stub(requestHelper, 'request', sinon.stub().rejects({response: {statusCode: 401}}))
+  .stub(inquirer, 'prompt', sinon.fake.returns({
+    response: 0,
+  }))
+  .stdout()
+  .quitsAfter(50)
+  .receivesLogAfter(10, fakePartialLog)
+  .pressesAfter(25, 'up')
+  .command('logs')
+  .skip('Will gracefully show errors when fetching a full log', ctx => {
+    expect(ctx.stdout).to.contain('Failed to fetch full log detail from Chec.io. (401)')
+  })
+})

--- a/test/commands/request.test.js
+++ b/test/commands/request.test.js
@@ -1,7 +1,20 @@
+/* global beforeEach afterEach */
+
 const {expect, test} = require('@oclif/test')
+const sinon = require('sinon')
+const authHelper = require('../../src/helpers/auth')
 
 describe('request', () => {
   describe('run', () => {
+    let isLoggedInMock
+
+    beforeEach(() => {
+      isLoggedInMock = sinon.stub(authHelper, 'isLoggedIn').returns(true)
+    })
+    afterEach(() => {
+      isLoggedInMock.restore()
+    })
+
     test
     .stdout()
     .command(['request', 'GET', '/v1/products', '{hello:"world"}'])
@@ -34,5 +47,11 @@ describe('request', () => {
     .it('prints the error responses', ctx => {
       expect(ctx.stdout).to.contain('Request failed')
     })
+
+    test
+    .do(() => isLoggedInMock.returns(false))
+    .command(['request', 'GET', '/v1/products', '{"limit":1}'])
+    .catch(error => expect(error.message).to.contain('You must be logged in to use this command'))
+    .it('Indicates that you must be logged in')
   })
 })

--- a/test/helpers/auth.test.js
+++ b/test/helpers/auth.test.js
@@ -62,7 +62,9 @@ describe('auth', () => {
     it('removes the keys config', () => {
       auth.logout()
 
-      expect(configRemoveStub.calledOnceWith('keys')).to.equal(true)
+      expect(configRemoveStub.calledTwice).to.equal(true)
+      expect(configRemoveStub.calledWithExactly('keys')).to.equal(true)
+      expect(configRemoveStub.calledWithExactly('notifications')).to.equal(true)
     })
   })
 })

--- a/test/helpers/config.test.js
+++ b/test/helpers/config.test.js
@@ -190,8 +190,16 @@ describe('config', () => {
       const config = new Config('fake/dir', '.checrc')
 
       expect(config.remove('two')).to.equal('2')
-
       expect(writeStub).to.have.been.calledOnceWith('fake/dir/.checrc', '{"one":1,"three":true}')
+    })
+
+    it('does\'t choke if the key doesn\'t exist', () => {
+      readStub.returns('{"one":1,"two":"2","three":true}')
+
+      const config = new Config('fake/dir', '.checrc')
+
+      expect(config.remove('four')).to.equal(undefined)
+      expect(writeStub).to.have.been.calledOnceWith('fake/dir/.checrc', '{"one":1,"two":"2","three":true}')
     })
   })
 })

--- a/test/helpers/config.test.js
+++ b/test/helpers/config.test.js
@@ -193,7 +193,7 @@ describe('config', () => {
       expect(writeStub).to.have.been.calledOnceWith('fake/dir/.checrc', '{"one":1,"three":true}')
     })
 
-    it('does\'t choke if the key doesn\'t exist', () => {
+    it('works with non-existent key', () => {
       readStub.returns('{"one":1,"two":"2","three":true}')
 
       const config = new Config('fake/dir', '.checrc')

--- a/test/helpers/log-entry.test.js
+++ b/test/helpers/log-entry.test.js
@@ -1,0 +1,176 @@
+/* global beforeEach afterEach */
+const requestHelper = require('../../src/helpers/request')
+const chai = require('chai')
+const dateFormat = require('date-format')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+
+const makeStub = () => {
+  const stub = sinon.stub()
+  stub.returnsArg(0)
+  return stub
+}
+const chalkStub = {
+  dim: makeStub(),
+  black: makeStub(),
+  yellow: makeStub(),
+  bgYellow: makeStub(),
+  bgGreen: makeStub(),
+  bgRed: makeStub(),
+}
+const coloriseStub = sinon.stub()
+const LogEntry = proxyquire('../../src/helpers/log-entry', {
+  'json-colorizer': coloriseStub,
+  chalk: chalkStub,
+})
+
+const {expect} = chai
+chai.use(sinonChai)
+
+const fakePartialLog = {
+  log_id: 123, // eslint-disable-line camelcase
+  status_code: 201, // eslint-disable-line camelcase
+  url: '/v1/fake/endpoint',
+  time: 1572304602,
+}
+const fakeFullLog = {
+  ...fakePartialLog,
+  response: {content: 'test response'},
+}
+
+const timestampAssertion = dateFormat('yyyy-MM-dd hh:mm:ss', new Date(1572304602000))
+
+describe('LogEntry', () => {
+  let requestMock
+  beforeEach(() => {
+    requestMock = sinon.stub(requestHelper, 'request')
+  })
+  afterEach(() => {
+    requestMock.restore()
+  })
+
+  describe('construction', () => {
+    it('requires at least a "log_id"', () => {
+      expect(() => new LogEntry({})).to.throw('LogEntry must be given a "raw" entry that at least contains the `log_id`')
+    })
+    it('does not do any requests', () => {
+      new LogEntry(fakePartialLog) // eslint-disable-line no-new
+      expect(requestMock).not.to.have.been.called
+    })
+    it('identifies a full log by the existence of a response', () => {
+      expect(new LogEntry(fakeFullLog)).to.have.own.property('full', true)
+    })
+  })
+
+  describe('id', () => {
+    it('returns the log_id', () => {
+      const log = new LogEntry(fakePartialLog)
+      expect(log.id()).to.equal(123)
+    })
+  })
+
+  describe('setPrinted', () => {
+    it('will indicate that the log entry has been printed', () => {
+      const log = new LogEntry(fakePartialLog)
+      expect(log.printed).to.equal(false)
+      log.setPrinted()
+      expect(log.printed).to.equal(true)
+    })
+
+    it('can be used to indicate the log has not been printed', () => {
+      const log = new LogEntry(fakePartialLog)
+      log.setPrinted()
+      expect(log.printed).to.equal(true)
+      log.setPrinted(false)
+      expect(log.printed).to.equal(false)
+    })
+  })
+
+  describe('getFullLog', () => {
+    beforeEach(() => {
+      requestMock.returns(Promise.resolve({body: JSON.stringify(fakeFullLog)}))
+    })
+
+    it('Returns the full value when the log is fully fetched, without dispatching a request', async () => {
+      const log = new LogEntry(fakeFullLog)
+      expect(await log.getFullLog()).to.equal(fakeFullLog)
+      expect(requestMock).not.to.have.been.called
+    })
+
+    it('dispatches a request for the full log if not fully loaded', async () => {
+      const log = new LogEntry(fakePartialLog)
+      expect(await log.getFullLog()).to.deep.equal(fakeFullLog)
+      expect(requestMock).to.have.been.calledOnceWithExactly('GET', '/v1/developer/logs/123', null, {domain: 'chec.io'})
+    })
+
+    it('should indicate the log is fully fetched and only dispatch one request for multiple calls', async () => {
+      const log = new LogEntry(fakePartialLog)
+      await log.getFullLog()
+      expect(log.full).to.be.true
+      expect(requestMock).to.have.been.calledOnce
+      await log.getFullLog()
+      expect(requestMock).to.have.been.calledOnce
+    })
+  })
+
+  describe('formattedLog', () => {
+    it('should use "colorise" on the existing log content', async () => {
+      coloriseStub.returns('a formatted string')
+      const log = new LogEntry(fakeFullLog)
+      expect(await log.formattedLog()).to.equal('a formatted string')
+      expect(coloriseStub).to.have.been.calledOnceWith(fakeFullLog, {pretty: true})
+    })
+  })
+
+  describe('formattedDate', () => {
+    it('should render the log\'s timestamp in a readable format', () => {
+      const log = new LogEntry(fakePartialLog)
+      expect(log.formattedDate()).to.equal(timestampAssertion)
+    })
+
+    it('should show UTC if specified', () => {
+      const log = new LogEntry(fakePartialLog)
+      expect(log.formattedDate(true)).to.equal('2019-10-28 23:16:42')
+    })
+  })
+
+  describe('formattedSummary', () => {
+    const colorOptions = ['bgYellow', 'bgGreen', 'bgRed']
+    beforeEach(() => {
+      colorOptions.forEach(key => {
+        chalkStub[key].resetHistory()
+      })
+    })
+    it('should render a line of information on the entry', () => {
+      const log = new LogEntry(fakePartialLog)
+      expect(log.formattedSummary()).to.equal(`[${timestampAssertion}]  201  123 /v1/fake/endpoint`)
+    })
+
+    it('passes through the UTC setting', () => {
+      const log = new LogEntry(fakePartialLog)
+      expect(log.formattedSummary(true)).to.equal('[2019-10-28 23:16:42]  201  123 /v1/fake/endpoint')
+    })
+
+    const options = [
+      [302, 'bgYellow'],
+      [201, 'bgGreen'],
+      [500, 'bgRed'],
+    ]
+
+    options.forEach(([code, colour]) => it(`should render ${code.toString()[0]}xx responses in ${colour.substring(2).toLowerCase()}`, () => {
+      const log = new LogEntry({
+        ...fakePartialLog,
+        status_code: code, // eslint-disable-line camelcase
+      })
+
+      log.formattedSummary()
+
+      // eslint-disable-next-line max-nested-callbacks
+      colorOptions.forEach(option => {
+        const method = option === colour ? 'called' : 'notCalled'
+        expect(chalkStub[option][method]).to.equal(true)
+      })
+    }))
+  })
+})

--- a/test/helpers/log-feed.test.js
+++ b/test/helpers/log-feed.test.js
@@ -1,0 +1,130 @@
+/* global beforeEach afterEach */
+
+const chai = require('chai')
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const config = require('../../src/helpers/config')
+
+class FakeChannel {
+  constructor(channel) {
+    this.channel = channel
+    this.bindFake = sinon.fake()
+    this.callbacks = []
+  }
+
+  bind(event, callback) {
+    this.callbacks.push(callback)
+    return this.bindFake(event, callback)
+  }
+}
+
+class FakePusher {
+  constructor(key, config) {
+    this.key = key
+    this.config = config
+    this.disconnectFake = sinon.fake()
+  }
+
+  subscribe(channel) {
+    return new FakeChannel(channel)
+  }
+
+  disconnect() {
+    this.disconnectFake()
+  }
+}
+
+const LogFeed = proxyquire('../../src/helpers/log-feed', {
+  'pusher-js': FakePusher,
+})
+
+const {expect} = chai
+chai.use(sinonChai)
+
+describe('LogFeed', () => {
+  let configGetMock
+  beforeEach(() => {
+    configGetMock = sinon.stub(config, 'get')
+    configGetMock.returns({
+      key: 'key',
+      token: 'token',
+    })
+  })
+  afterEach(() => {
+    configGetMock.restore()
+  })
+
+  describe('getConfiguration', () => {
+    it('should get the "notifications" key from config', () => {
+      (new LogFeed()).getConfiguration()
+      expect(configGetMock).to.have.been.calledOnceWithExactly('notifications')
+    })
+    it('should error if the required config is not available', () => {
+      configGetMock.returns(null)
+      expect(() => (new LogFeed()).getConfiguration()).to.throw('Could not locate required credentials to subscribe to a log feed')
+    })
+    it('will return a key and token', () => {
+      expect((new LogFeed()).getConfiguration()).to.deep.equal({
+        key: 'key',
+        token: 'token',
+      })
+    })
+  })
+
+  describe('getChannel', () => {
+    it('creates a pusher socket and channel', () => {
+      const feed = new LogFeed()
+      expect(feed.socket).to.be.null
+      expect(feed.channel).to.be.null
+      feed.getChannel()
+      expect(feed.socket).to.be.instanceOf(FakePusher)
+      expect(feed.channel).to.be.instanceOf(FakeChannel)
+    })
+
+    it('reuses an existing socket and channel', () => {
+      const feed = new LogFeed()
+      const channel = feed.getChannel()
+      const socket = feed.socket
+      const newChannel = feed.getChannel()
+      expect(newChannel).to.equal(channel)
+      expect(feed.socket).to.equal(socket)
+    })
+  })
+
+  describe('disconnect', () => {
+    it('doesn\'t choke without a socket', () => {
+      const feed = new LogFeed()
+      expect(() => feed.disconnect()).not.to.throw()
+      expect(feed.socket).to.be.null
+    })
+    it('calls disconnect on a pusher instance', () => {
+      const feed = new LogFeed()
+      feed.getChannel()
+      feed.disconnect()
+      expect(feed.socket.disconnectFake).to.have.been.called
+    })
+  })
+
+  describe('onLog', () => {
+    it('creates a socket and channel if required', () => {
+      const feed = new LogFeed()
+      feed.onLog(() => {})
+      expect(feed.channel).to.be.instanceOf(FakeChannel)
+      expect(feed.socket).to.be.instanceOf(FakePusher)
+    })
+    it('calls bind on a channel', () => {
+      const feed = new LogFeed()
+      feed.onLog(() => {})
+      expect(feed.channel.bindFake).to.have.been.calledOnceWith('log')
+    })
+    it('proxies the given callback to provide the specific log', () => {
+      const feed = new LogFeed()
+      const callback = sinon.fake()
+      feed.onLog(callback)
+      const boundCallback = feed.channel.callbacks.pop()
+      boundCallback({log: 'a log'})
+      expect(callback).to.have.been.calledOnceWithExactly('a log')
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,6 +358,11 @@ append-transform@^1.0.0:
   dependencies:
     default-require-extensions "^2.0.0"
 
+arch@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/arch/-/arch-2.1.1.tgz#8f5c2731aa35a30929221bb0640eed65175ec84e"
+  integrity sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==
+
 archy@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
@@ -575,6 +580,14 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
+clipboardy@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-2.1.0.tgz#0123a0c8fac92f256dc56335e0bb8be97a4909a5"
+  integrity sha512-2pzOUxWcLlXWtn+Jd6js3o12TysNOOVes/aQfg+MT/35vrxWzedHlLwyoJpXjsFKWm95BTNEcMGD9+a7mKzZkQ==
+  dependencies:
+    arch "^2.1.1"
+    execa "^1.0.0"
+
 cliui@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
@@ -663,6 +676,11 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+date-format@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/date-format/-/date-format-2.1.0.tgz#31d5b5ea211cf5fd764cd38baf9d033df7e125cf"
+  integrity sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==
 
 debug@3.1.0:
   version "3.1.0"
@@ -1595,6 +1613,14 @@ json-buffer@3.0.0:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
 
+json-colorizer@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/json-colorizer/-/json-colorizer-2.2.1.tgz#ff0a19efb527614c3c8642bfdb0310f1018086bc"
+  integrity sha512-2GMM3+7rygnfVyCNgqyyl52P3SYLR08FA2LAEKPfbSsp+GtPJPk+hTgiQq5EXawi/Gzmn4iEHf9M2/aF9U7J3w==
+  dependencies:
+    chalk "^2.4.1"
+    lodash.get "^4.4.2"
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -2299,6 +2325,11 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+pusher-js@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/pusher-js/-/pusher-js-5.0.2.tgz#bb65976d0a093e98a6e222020586ae72e5bd4bc4"
+  integrity sha512-onQui1AwE+Z0ab3kvSruz5TgW+i4qr98fN0jgV/iLlkj2B+LWtqcP+kh9H8sPmHOEnwayhhkNJHaC6jGLHHl7w==
 
 qqjs@^0.3.10:
   version "0.3.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1099,6 +1099,14 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
+fill-keys@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fill-keys/-/fill-keys-1.0.2.tgz#9a8fa36f4e8ad634e3bf6b4f3c8882551452eb20"
+  integrity sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=
+  dependencies:
+    is-object "~1.0.1"
+    merge-descriptors "~1.0.0"
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -1493,6 +1501,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-object@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+  integrity sha1-iVJojF7C/9awPsyF52ngKQMINHA=
+
 is-plain-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.0.0.tgz#7fd1a7f1b69e160cde9181d2313f445c68aa2679"
@@ -1843,6 +1856,11 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
+merge-descriptors@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+  integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
+
 merge-source-map@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
@@ -1923,6 +1941,11 @@ mock-stdin@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/mock-stdin/-/mock-stdin-0.3.1.tgz#c657d9642d90786435c64ca5e99bbd4d09bd7dd3"
   integrity sha1-xlfZZC2QeGQ1xkyl6Zu9TQm9fdM=
+
+module-not-found-error@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
+  integrity sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=
 
 ms@2.0.0:
   version "2.0.0"
@@ -2308,6 +2331,15 @@ propagate@^2.0.0:
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
   integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
+proxyquire@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-2.1.3.tgz#2049a7eefa10a9a953346a18e54aab2b4268df39"
+  integrity sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==
+  dependencies:
+    fill-keys "^1.0.2"
+    module-not-found-error "^1.0.1"
+    resolve "^1.11.1"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -2429,7 +2461,7 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-resolve@^1.10.0, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.11.1, resolve@^1.8.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==


### PR DESCRIPTION
Introduces the `logs` command that streams logs, optionally fetches prior logs, and allow navigation through the logs to get further detail.
Also introduces the `log` command for fetching full detail for a specific logs 

~I still need to smash together a bunch of tests for this~