### PR TITLE
chec_api_url value now has a protocol attached to it

### DIFF
--- a/src/commands/demo-store.js
+++ b/src/commands/demo-store.js
@@ -362,7 +362,7 @@ ${chalk.dim(manifest.description)}`)
       },
       {
         regex: /^%chec_api_url%$/,
-        getter: () => `api.${domain}`,
+        getter: () => domain === 'chec.local' ? `http://api.${domain}` : `https://api.${domain}`,
       },
     ]
 

--- a/test/commands/demo-store.test.js
+++ b/test/commands/demo-store.test.js
@@ -257,7 +257,7 @@ describe('demo-store', () => {
     expect(envMock.set).to.have.been.calledWith('string', 'content')
     expect(envMock.set).to.have.been.calledWith('key', 'public')
     expect(envMock.set).to.have.been.calledWith('secret', 'secret')
-    expect(envMock.set).to.have.been.calledWith('api_url', 'api.chec.example')
+    expect(envMock.set).to.have.been.calledWith('api_url', 'https://api.chec.example')
   })
 
   test


### PR DESCRIPTION
Ideally the local domain would support HTTPS, but until then we need something like this.