### PR TITLE
Fix links to source files in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ DESCRIPTION
   the downloaded code and play around with Commerce.js in client code
 ```
 
-_See code: [src/commands/demo-store.js](https://github.com/chec/cli/blob/v1.0.0/src/commands/demo-store.js)_
+_See code: [src/commands/demo-store.js](https://github.com/chec/cli/blob/1.0.0/src/commands/demo-store.js)_
 
 ## `chec help [COMMAND]`
 
@@ -98,7 +98,7 @@ DESCRIPTION
   Communicates with Chec to get full log information for the given log ID
 ```
 
-_See code: [src/commands/log.js](https://github.com/chec/cli/blob/v1.0.0/src/commands/log.js)_
+_See code: [src/commands/log.js](https://github.com/chec/cli/blob/1.0.0/src/commands/log.js)_
 
 ## `chec login`
 
@@ -117,7 +117,7 @@ DESCRIPTION
   Log into your Chec account to enable commands that require API access.
 ```
 
-_See code: [src/commands/login.js](https://github.com/chec/cli/blob/v1.0.0/src/commands/login.js)_
+_See code: [src/commands/login.js](https://github.com/chec/cli/blob/1.0.0/src/commands/login.js)_
 
 ## `chec logout`
 
@@ -131,7 +131,7 @@ DESCRIPTION
   Log out of your account and remove the local copy of your API keys.
 ```
 
-_See code: [src/commands/logout.js](https://github.com/chec/cli/blob/v1.0.0/src/commands/logout.js)_
+_See code: [src/commands/logout.js](https://github.com/chec/cli/blob/1.0.0/src/commands/logout.js)_
 
 ## `chec logs`
 
@@ -153,7 +153,7 @@ DESCRIPTION
   from Chec.
 ```
 
-_See code: [src/commands/logs.js](https://github.com/chec/cli/blob/v1.0.0/src/commands/logs.js)_
+_See code: [src/commands/logs.js](https://github.com/chec/cli/blob/1.0.0/src/commands/logs.js)_
 
 ## `chec register`
 
@@ -167,7 +167,7 @@ DESCRIPTION
   Sign up for a Chec account through your browser
 ```
 
-_See code: [src/commands/register.js](https://github.com/chec/cli/blob/v1.0.0/src/commands/register.js)_
+_See code: [src/commands/register.js](https://github.com/chec/cli/blob/1.0.0/src/commands/register.js)_
 
 ## `chec request METHOD RESOURCE [PAYLOAD]`
 
@@ -200,7 +200,7 @@ EXAMPLES
   $ chec request POST /v1/assets --file=my-asset-payload.json
 ```
 
-_See code: [src/commands/request.js](https://github.com/chec/cli/blob/v1.0.0/src/commands/request.js)_
+_See code: [src/commands/request.js](https://github.com/chec/cli/blob/1.0.0/src/commands/request.js)_
 
 ## `chec whoami`
 
@@ -217,5 +217,5 @@ EXAMPLE
   $ chec whoami
 ```
 
-_See code: [src/commands/whoami.js](https://github.com/chec/cli/blob/v1.0.0/src/commands/whoami.js)_
+_See code: [src/commands/whoami.js](https://github.com/chec/cli/blob/1.0.0/src/commands/whoami.js)_
 <!-- commandsstop -->


### PR DESCRIPTION
The links to the source files point to the `v1.0.0` tag, which doesn't exist.
This patch fixes them to point to the right tag, `1.0.0`.