### PR TITLE
Demo-store command asking about running seeding scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ OPTIONS
   --no-login  Optionally skip the login requirement. This is likely to be incompatible with example stores that are
               available for download
 
-  --no-seed  Skip the extra scripts seeding in the demo store
+  --no-seed   Optionally skip seeding sample data into your Chec account
 
 DESCRIPTION
   This command will download an example project from GitHub and initialise it on your machine. You will be free to edit 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ OPTIONS
   --no-login  Optionally skip the login requirement. This is likely to be incompatible with example stores that are
               available for download
 
+  --no-seed  Skip the extra scripts seeding in the demo store
+
 DESCRIPTION
   This command will download an example project from GitHub and initialise it on your machine. You will be free to edit 
   the downloaded code and play around with Commerce.js in client code

--- a/src/commands/demo-store.js
+++ b/src/commands/demo-store.js
@@ -26,7 +26,7 @@ class DemoStoreCommand extends Command {
 
     // Check that the user provided a store and if it's something that's known before going and updating our cache
     if (!store || !this.getStoreFromCache(store)) {
-      await this.retreiveStores()
+      await this.retrieveStores()
     }
 
     // If the user didn't specify a store, ask them
@@ -66,7 +66,7 @@ class DemoStoreCommand extends Command {
    *
    * @return {Promise<Array>} A promise that resolves to the list of stores fetched freshly from GitHub
    */
-  async retreiveStores() {
+  async retrieveStores() {
     if (this.stores) {
       return this.stores
     }
@@ -95,7 +95,7 @@ class DemoStoreCommand extends Command {
    */
   async askForStore() {
     // Grab the stores and _clone_ the array
-    const stores = (await this.retreiveStores()).slice(0)
+    const stores = (await this.retrieveStores()).slice(0)
 
     // Return the only store if there's one
     if (stores.length === 1) {

--- a/src/commands/demo-store.js
+++ b/src/commands/demo-store.js
@@ -285,12 +285,13 @@ ${chalk.dim(manifest.description)}`)
     .streamOutput(true, true)
     .run()
 
+    // Handle opting out of seeding
     let {flags: {'no-seed': noSeed}} = this.parse(DemoStoreCommand)
     if (!noSeed) {
       const {seed} = await inquirer.prompt([{
         type: 'confirm',
         name: 'seed',
-        message: 'Do you want to run the seed scripts for this store?',
+        message: 'Do you want to seed sample data into your Chec account?',
         default: true,
       }])
 
@@ -298,8 +299,11 @@ ${chalk.dim(manifest.description)}`)
     }
 
     if (noSeed) {
-      this.log(chalk.yellow('Skipping additional build/seed scripts...'))
-      return
+      this.log(chalk.yellow('Skipping seeding sample data...'))
+      const seedIndex = buildScripts.indexOf('seed')
+      if (seedIndex > -1) {
+        buildScripts.splice(seedIndex, 1)
+      }
     }
 
     this.log(chalk.dim('Running additional build/seed scripts...'))
@@ -433,7 +437,7 @@ DemoStoreCommand.flags = {
     default: false,
   }),
   'no-seed': flags.boolean({
-    description: 'Skip the extra scripts seeding in the demo store',
+    description: 'Optionally skip seeding sample data into your Chec account',
     default: false,
   }),
   ...globalFlags,

--- a/src/commands/demo-store.js
+++ b/src/commands/demo-store.js
@@ -285,7 +285,24 @@ ${chalk.dim(manifest.description)}`)
     .streamOutput(true, true)
     .run()
 
-    // Loop through additional scripts and await their execution
+    let {flags: {'no-seed': noSeed}} = this.parse(DemoStoreCommand)
+    if (!noSeed) {
+      const {seed} = await inquirer.prompt([{
+        type: 'confirm',
+        name: 'seed',
+        message: 'Do you want to run the seed scripts for this store?',
+        default: true,
+      }])
+
+      noSeed = !seed
+    }
+
+    if (noSeed) {
+      this.log(chalk.yellow('Skipping additional build/seed scripts...'))
+      return
+    }
+
+    this.log(chalk.dim('Running additional build/seed scripts...'))
     for (const script of buildScripts) {
       // eslint-disable-next-line no-await-in-loop
       await spawner.create(command, [...baseArgs, 'run', script], {stdio: 'inherit'}).run()
@@ -413,6 +430,10 @@ DemoStoreCommand.flags = {
   }),
   'no-login': flags.boolean({
     description: 'Optionally skip the login requirement. This is likely to be incompatible with example stores that are available for download',
+    default: false,
+  }),
+  'no-seed': flags.boolean({
+    description: 'Skip the extra scripts seeding in the demo store',
     default: false,
   }),
   ...globalFlags,

--- a/test/commands/demo-store.test.js
+++ b/test/commands/demo-store.test.js
@@ -323,19 +323,6 @@ describe('demo-store', () => {
   mockZipStream(base, 'basic-project', 'fake')
   .stub(spawner, 'create', sinon.stub().returns(mockSpawner))
   .stdout()
-  .command(['demo-store', 'npm-test', '/given/directory', '--no-seed'])
-  .it('Does not runs NPM install and scripts if no-seed flag is used', function () {
-    this.slow(600)
-
-    expect(spawner.create).to.have.callCount(1)
-
-    expect(spawner.create).to.have.been.calledWith('npm', ['--prefix', '/given/directory', 'install'])
-    expect(spawner.create).not.to.have.been.calledWith('npm', ['--prefix', '/given/directory', 'run', 'fake'])
-  })
-
-  mockZipStream(base, 'basic-project', 'fake')
-  .stub(spawner, 'create', sinon.stub().returns(mockSpawner))
-  .stdout()
   .command(['demo-store', 'yarn-test', '/given/directory'])
   .it('Uses yarn instead of NPM if configured', function () {
     this.slow(600)

--- a/test/commands/demo-store.test.js
+++ b/test/commands/demo-store.test.js
@@ -323,6 +323,19 @@ describe('demo-store', () => {
   mockZipStream(base, 'basic-project', 'fake')
   .stub(spawner, 'create', sinon.stub().returns(mockSpawner))
   .stdout()
+  .command(['demo-store', 'npm-test', '/given/directory', '--no-seed'])
+  .it('Does not runs NPM install and scripts if no-seed flag is used', function () {
+    this.slow(600)
+
+    expect(spawner.create).to.have.callCount(1)
+
+    expect(spawner.create).to.have.been.calledWith('npm', ['--prefix', '/given/directory', 'install'])
+    expect(spawner.create).not.to.have.been.calledWith('npm', ['--prefix', '/given/directory', 'run', 'fake'])
+  })
+
+  mockZipStream(base, 'basic-project', 'fake')
+  .stub(spawner, 'create', sinon.stub().returns(mockSpawner))
+  .stdout()
   .command(['demo-store', 'yarn-test', '/given/directory'])
   .it('Uses yarn instead of NPM if configured', function () {
     this.slow(600)


### PR DESCRIPTION
Closes #28 

I am having problems with the tests, as I've never used `mocha` and `sinon` before (I always use `jest`). I don't understand why the  new test on the `demo-store ` command test would fail, neither understand why tests would fail in other commands (such as it is now), as they don't call the code I've written. How can I mock the `inquirer.prompt` so that it correctly handles the login prompt or the seeding prompt?

I've tested the code per se, bringing it to the beginning of the demo-store command, and it works as intended:
![image](https://user-images.githubusercontent.com/32079912/96070901-79a9cb80-0e77-11eb-9cf9-d96be93f76ea.png)
